### PR TITLE
fix countable error

### DIFF
--- a/src/Socket/AsyncSelector.php
+++ b/src/Socket/AsyncSelector.php
@@ -143,7 +143,7 @@ class AsyncSelector
             throw new SocketException('Failed to select sockets');
         }
 
-        $result = count($read) + count($write) + count($oob);
+        $result = count($read ?? []) + count($write ?? []) + count($oob);
         if ($result === 0) {
             throw new TimeoutException('Select operation was interrupted during timeout');
         }


### PR DESCRIPTION
this line triggers a warning: "Warning: count(): Parameter must be an array or an object that implements Countable" since `$read` may be `null` and `count(null)` is not ok.
p.s. why at all the `$read` should be `= null` and not `= []`?